### PR TITLE
Gradle 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,4 @@
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-    }
-}
-
 apply plugin: 'com.android.library'
 
 android {


### PR DESCRIPTION
Gradle 9 removed jcenter() entirely - having it declared anywhere causes a build failure ("Could not find method jcenter()").

Changes to android/build.gradle:
- Removed the entire buildscript block (declared jcenter() + AGP 3.1.2 classpath). The block is only needed when building the library standalone; when included as a subproject the host app's buildscript provides the AGP. The pinned AGP 3.1.2 (2018) also conflicts with modern AGP versions.
- The repositories block (mavenCentral() only) was already clean - no change needed there.